### PR TITLE
docs(readme): add missing hyperkit driver installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $ brew install docker-machine-driver-hyperkit
 
 ```bash
 $ brew cask install minikube
+$ brew install docker-machine-driver-hyperkit
 $ minikube start --vm-driver=hyperkit
 $ minikube addons enable coredns
 $ minikube addons enable ingress


### PR DESCRIPTION
I had to do it somehow, https://github.com/Homebrew/homebrew-core/pull/28076