### PR TITLE
Fix exit not found error in readiness probe manifest

### DIFF
--- a/11-probes/02-readiness-probe.yml
+++ b/11-probes/02-readiness-probe.yml
@@ -21,8 +21,9 @@ spec:
           readinessProbe:
             exec:
               command:
-                - exit
-                - "1"
+                - /bin/bash
+                - -c
+                - "exit 1"
             initialDelaySeconds: 5
             periodSeconds: 5
 ---


### PR DESCRIPTION
Same error as in the liveness probe, should have checked before...