### PR TITLE
fix: sidecar manifest

### DIFF
--- a/16-sidecar-containers/01-sidecar.yml
+++ b/16-sidecar-containers/01-sidecar.yml
@@ -11,12 +11,12 @@ spec:
     - name: nginx
       image: nginx
       volumeMounts:
-        - name: data
+        - name: shared-data
           mountPath: /usr/share/nginx/html
     - name: debian
       image: debian
       volumeMounts:
-        - name: data
+        - name: shared-data
           mountPath: /pod-data
       command: ["/bin/sh"]
       args: ["-c", "echo Hello from the debian container > /pod-data/index.html"]


### PR DESCRIPTION
**Summary:**
Fix the sidecar manifest that had the wrong volume name.

**Test plan:**
`kubectl apply -f 01-sidecar.yml`
`pod/two-containers created`