### PR TITLE
Fix kubectl exec

### DIFF
--- a/10-secrets/README.md
+++ b/10-secrets/README.md
@@ -50,7 +50,7 @@ spec:
 You can look up the secrets in the pod by connecting to the pod:
 
 ```sh
-$ kubectl exec -ti redis-with-volume-secrets /bin/bash
+$ kubectl exec -ti redis-with-volume-secrets -- /bin/bash
 root@redis-with-volume-secrets:/data# cd /etc/foo/
 root@redis-with-volume-secrets:/etc/foo# ls
 password  username


### PR DESCRIPTION
Error:
```
$> kubectl exec -ti redis-with-volume-secrets /bin/bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
error: unable to upgrade connection: container not found ("redis")
```