### PR TITLE
Update apiVersion to v1

### DIFF
--- a/09-cronjob/01-simple-cronjob.yml
+++ b/09-cronjob/01-simple-cronjob.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: simple-cronjob


### PR DESCRIPTION
`batch/v1beta` will be deprecated soon (unavailable in v1.25+) so moving to `batch/v1`