### PR TITLE
[doc] update the doc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 ---
 version: 2.1
+orbs:
+  yamllint: freighthub/yamllint@1.0.0
+
 jobs:
   lint-yml:
     docker:
@@ -8,14 +11,14 @@ jobs:
       - checkout
       - run:
           name: install yamllint
-          command: sudo pip install yamllint
+          command: pip install --user yamllint
       - run:
           name: lint yml
-          command: yamllint .
+          command: /home/circleci/.local/bin/yamllint .
 
   lint-md:
     docker:
-      - image: circleci/node:12
+      - image: cimg/node:18.10.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,21 @@
 ---
 version: 2.1
-orbs:
-  yamllint: freighthub/yamllint@1.0.0
-
 jobs:
   lint-yml:
     docker:
-      - image: circleci/python:3.7.3
+      - image: cimg/python:3.10
     steps:
       - checkout
       - run:
           name: install yamllint
-          command: pip install --user yamllint
+          command: pip install yamllint
       - run:
           name: lint yml
-          command: /home/circleci/.local/bin/yamllint .
+          command: yamllint .
 
   lint-md:
     docker:
-      - image: cimg/node:18.10.0
+      - image: cimg/node:18.10
     steps:
       - checkout
       - run:

--- a/.yamllint
+++ b/.yamllint
@@ -1,3 +1,4 @@
+---
 extends: default
 
 rules:

--- a/05-pods/README.md
+++ b/05-pods/README.md
@@ -74,7 +74,7 @@ Our first `pod` is now running. Now `describe` it. `describe` is a `get` on ster
 $ kubectl describe pod simple-pod
 [a lot of stuff]
 
-IP: 172.17.0.1
+IP: 172.17.0.4
 
 [more stuff]
 ```

--- a/07-deployment/README.md
+++ b/07-deployment/README.md
@@ -116,11 +116,23 @@ You can also use `kubectl scale`:
 kubectl scale --replicas=5 -f 07-deployment/01-simple-deployment.yml
 ```
 
+Check the number of pods you have now:
+```sh
+kubectl get pod
+NAME                                 READY   STATUS    RESTARTS   AGE
+simple-deployment-7679fffff7-77wr2   1/1     Running   0          23m
+simple-deployment-7679fffff7-hv494   1/1     Running   0          23m
+simple-deployment-7679fffff7-kg55p   1/1     Running   0          38s
+simple-deployment-7679fffff7-x5cdb   1/1     Running   0          38s
+simple-deployment-7679fffff7-zhm72   1/1     Running   0          38s
+```
+
 You can also edit the manifest in place with `kubectl edit`:
 
 ```sh
 kubectl edit deployment simple-deployment
 ```
+The changes are applied immediately after saving the deployment manifest. `kubectl get pod` to check.
 
 I would recommend to only use `kubectl apply` as it is declarative and local to your computer, so you can commit it afterwards.
 

--- a/07-deployment/README.md
+++ b/07-deployment/README.md
@@ -117,6 +117,7 @@ kubectl scale --replicas=5 -f 07-deployment/01-simple-deployment.yml
 ```
 
 Check the number of pods you have now:
+
 ```sh
 kubectl get pod
 NAME                                 READY   STATUS    RESTARTS   AGE
@@ -132,6 +133,7 @@ You can also edit the manifest in place with `kubectl edit`:
 ```sh
 kubectl edit deployment simple-deployment
 ```
+
 The changes are applied immediately after saving the deployment manifest. `kubectl get pod` to check.
 
 I would recommend to only use `kubectl apply` as it is declarative and local to your computer, so you can commit it afterwards.

--- a/08-service/04-ingress.yml
+++ b/08-service/04-ingress.yml
@@ -1,11 +1,13 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: simple-ingress
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
-  backend:
-    serviceName: simple-internal-service
-    servicePort: 80
+  defaultBackend:
+    service:
+      name: simple-internal-service
+      port:
+        number: 80

--- a/08-service/README.md
+++ b/08-service/README.md
@@ -122,16 +122,18 @@ You need to connect internet to the `ingress` that'll connect it to a service:
 Let's create our ingress:
 
 ```yml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: simple-ingress
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
-  backend:
-    serviceName: simple-internal-service
-    servicePort: 80
+  defaultBackend:
+    service:
+      name: simple-internal-service
+      port:
+        number: 80
 ```
 
 Let's have a look at the manifest:
@@ -141,9 +143,9 @@ Let's have a look at the manifest:
   * `annotations`: some annotations specific to the ingress
     * `nginx.ingress.kubernetes.io/ssl-redirect`: To fix a redirect, see [this](https://github.com/kubernetes/ingress-nginx/issues/1567). This is only used if you use the nginx ingress
 * `spec`:
-  * `backend`: the default backend to redirect all the requests to
-    * `serviceName`: the name of the Kubernetes traffic to redirect to
-    * `servicePort`: the port of the service
+  * `defaultBackend`: the default backend to redirect all the requests to
+    * `service.name`: the name of the Kubernetes traffic to redirect to
+    * `service.port.number`: the port of the service
 
 Apply the ingress:
 

--- a/08-service/README.md
+++ b/08-service/README.md
@@ -10,7 +10,7 @@ If it's not already done install the `minikube` addon `ingress`:
 
 ```sh
 $ minikube addons enable ingress
-✅  ingress was successfully enabled
+🌟  The 'ingress' addon is enabled
 ```
 
 ## First `service`
@@ -151,7 +151,7 @@ Apply the ingress:
 
 ```sh
 $ kubectl apply -f 08-service/04-ingress.yml
-ingress.extensions "simple-ingress" created
+ingress.networking.k8s.io/simple-ingress created
 ```
 
 Get the IP of your minikube cluster:

--- a/README.md
+++ b/README.md
@@ -49,10 +49,8 @@ This hands-on course in under the [CC BY-NC-SA](./LICENSE) license.
 - Docker: <https://docs.docker.com/docker-for-mac/install/>
 
 ```sh
-open https://download.docker.com/mac/stable/Docker.dmg
+brew install --cask docker
 ```
-
-- VirtualBox: <https://www.virtualbox.org/wiki/Downloads>
 
 - minikube: <https://github.com/kubernetes/minikube>
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,36 @@
 # Kubernetes Hands on
 
-1. [Prerequisites](#prerequisites)
-1. [What it is not](#what-it-is-not)
-1. [What is Kubernetes? What is it used for?](#what-is-kubernetes-what-is-it-used-for)
-1. [Glossary](#glossary)
-1. [The base building block: pods](#the-base-building-block-pods)
-1. [Naming things: labels and annotations](#naming-things-labels-and-annotations)
-1. [Deploying your first application: deployment](#deploying-my-first-application-deployment)
-1. [Accessing your first application: service](#accessing-my-first-application-service)
-1. [Running a background process: cronjobs](#running-a-background-process-cronjobs)
-1. [Secrets](#secrets)
-1. [Liveness and readiness probes, and how it impacts your pods](#liveness-and-readiness-probes,-and-how-it-impacts-your-pods)
-1. [Resources, and how it impacts the scheduling](#resources,-and-how-it-impacts-the-scheduling)
-1. [Improving the availability of your application: affinity and anti-affinity](#affinity-and-anti-affinity)
-1. [Improving the availability of your application: pod disruptions budget](#pdb)
-1. [Improving the elasticity of your applications: HPA, VPA](#hpa-vpa)
-1. [Sidecar containers: what, why, and how](#sidecar-containers-what,-why,-and-how)
-1. [Running a stateful application: volumes](#running-a-stateful-application-volumes)
-1. [Running a stateful application: stateful-sets](#running-a-stateful-application-stateful-sets)
-1. [Controllers: what, why, and how](#controllers-what,-why,-and-how)
-1. [Operators and CRDs: what, why, and how](#operators-and-crds-what,-why,-and-how)
-1. [RBAC](#rbac)
-1. [Other topics](#other-topics)
-1. [Good practices](#good-practices)
-1. [Links](#links)
+- [Kubernetes Hands on](#kubernetes-hands-on)
+  - [License](#license)
+  - [Prerequisites](#prerequisites)
+    - [(Fixed) docker: Ingress not exposed on MacOS](#fixed-docker-ingress-not-exposed-on-macos)
+    - [(Optional) If you feel adventurous, only for macOS](#optional-if-you-feel-adventurous-only-for-macos)
+    - [Completion](#completion)
+  - [What this course is and what it's not](#what-this-course-is-and-what-its-not)
+    - [What this is](#what-this-is)
+    - [What it's *not*](#what-its-not)
+  - [What is Kubernetes? What is it used for](#what-is-kubernetes-what-is-it-used-for)
+  - [Glossary](#glossary)
+  - [The base building block: pods](#the-base-building-block-pods)
+  - [Naming things: labels and annotations](#naming-things-labels-and-annotations)
+  - [Deploying my first application: deployment](#deploying-my-first-application-deployment)
+  - [Accessing my first application: service](#accessing-my-first-application-service)
+  - [Running a background process: cronjobs](#running-a-background-process-cronjobs)
+  - [Secrets](#secrets)
+  - [Liveness and readiness probes, and how it impacts your pods](#liveness-and-readiness-probes-and-how-it-impacts-your-pods)
+  - [Resources, and how it impacts the scheduling](#resources-and-how-it-impacts-the-scheduling)
+  - [Affinity and anti-affinity](#affinity-and-anti-affinity)
+  - [PDB](#pdb)
+  - [HPA, VPA](#hpa-vpa)
+  - [Sidecar containers: what, why, and how](#sidecar-containers-what-why-and-how)
+  - [Running a stateful application: volumes](#running-a-stateful-application-volumes)
+  - [Running a stateful application: stateful sets](#running-a-stateful-application-stateful-sets)
+  - [Controllers: what, why, and how](#controllers-what-why-and-how)
+  - [Operators and CRDs: what, why, and how](#operators-and-crds-what-why-and-how)
+  - [RBAC](#rbac)
+  - [Other topics](#other-topics)
+  - [Good practices](#good-practices)
+  - [Links](#links)
 
 ## License
 
@@ -33,21 +40,21 @@ This hands-on course in under the [CC BY-NC-SA](./LICENSE) license.
 
 ## Prerequisites
 
-* Homebrew: <https://brew.sh/>
+- Homebrew: <https://brew.sh/>
 
 ```sh
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
 
-* Docker: <https://docs.docker.com/docker-for-mac/install/>
+- Docker: <https://docs.docker.com/docker-for-mac/install/>
 
 ```sh
 open https://download.docker.com/mac/stable/Docker.dmg
 ```
 
-* VirtualBox: <https://www.virtualbox.org/wiki/Downloads>
+- VirtualBox: <https://www.virtualbox.org/wiki/Downloads>
 
-* minikube: <https://github.com/kubernetes/minikube>
+- minikube: <https://github.com/kubernetes/minikube>
 
 Install minikube and the "ingress" and "metrics-server" addons:
 
@@ -55,7 +62,7 @@ Install minikube and the "ingress" and "metrics-server" addons:
 $ brew install kubectl
 [...]
 
-$ brew cask install minikube
+$ brew install minikube
 [...]
 
 $ minikube start
@@ -72,8 +79,12 @@ $ kubectl config current-context
 minikube
 ```
 
-**Note:** the ingress addon is currently not supported on docker for Mac (see https://github.com/kubernetes/minikube/issues/7332).
-As a workaround, you have to deploy minikube as a VM and not as a container (using Virtualbox or Hyperkit for example)
+### (Fixed) docker: Ingress not exposed on MacOS
+
+[fixed on August 2021](https://github.com/kubernetes/minikube/pull/12089)
+
+**Note:*- the ingress addon not being supported on docker for Mac (see https://github.com/kubernetes/minikube/issues/7332).
+As a workaround, you had to deploy minikube as a VM and not as a container (using Virtualbox or Hyperkit for example)
 
 ```sh
 $ minikube start --vm=true --vm-driver=virtualbox
@@ -96,7 +107,7 @@ $ minikube stop && minikube delete && minikube start --vm=true --vm-driver=virtu
 
 You can try another lighter virtual machine layer than Virtualbox
 
-* HyperKit: <https://github.com/moby/hyperkit>
+- HyperKit: <https://github.com/moby/hyperkit>
 
 ```sh
 brew install docker-machine-driver-hyperkit
@@ -130,7 +141,7 @@ if [ $commands[kubectl] ]; then
 fi
 ```
 
-## What this course is and what it's *not*
+## What this course is and what it's not
 
 ### What this is
 
@@ -149,65 +160,65 @@ Kubernetes is an open-source system for managing containerized applications acro
 
 Kubernetes has a number of features. It can be seen as:
 
-* a container platform,
-* a microservices platform,
-* a portable cloud platform, and a lot more.
+- a container platform,
+- a microservices platform,
+- a portable cloud platform, and a lot more.
 
 Kubernetes provides a container-centric management environment. It orchestrates computing, networking, and storage infrastructure on behalf of user workloads. This provides much of the simplicity of Platform as a Service (PaaS) with the flexibility of Infrastructure as a Service (IaaS), and enables portability across infrastructure providers.
 
 ## Glossary
 
-* **YAML (yml)**
+- **YAML (yml)**
 
 A markup language that relies on spaces and tabulations. All Kubernetes configuration is written using YAML.
 
 You will feel the pain of missing tabs and spaces. Feel free to use a linter, such as <http://www.yamllint.com/>.
 
-* **Container**
+- **Container**
 
-*Containers* are an abstraction at the app layer, which packages code and dependencies together.
+*Containers- are an abstraction at the app layer, which packages code and dependencies together.
 
-* **(Container) image**
+- **(Container) image**
 
 A lightweight, standalone, executable software package that includes everything you need to run an application: code, runtime, system tools, system libraries and settings.
 
-* **Docker**
+- **Docker**
 
 A software technology providing operating-system-level virtualization, also known as containers.
 
 Docker uses the resource isolation features of the Linux kernel, such as cgroups and kernel namespaces, and a union-capable file system such as OverlayFS and others to allow independent “containers” to run within a single Linux instance. This avoids the overhead of starting and maintaining virtual machines (VMs).
 
-* **kubectl**
+- **kubectl**
 
 The standard CLI to interact with Kubernetes. We use it a lot in this course.
 
-* **minikube**
+- **minikube**
 
 A local Kubernetes cluster, useful for testing. We use it a lot in this course.
 
-* **Manifest**
+- **Manifest**
 
 Kubernetes configuration files are called *manifests*. This is a reference to the list or invoice of the passengers or goods being carried by a commercial vehicle or ship (from [wiktionary](https://en.wiktionary.org/wiki/manifest#Noun)).
 
-* **(Kubernetes) objects**
+- **(Kubernetes) objects**
 
-Kubernetes contains a number of abstractions that represent the state of your system: deployed containerized applications and workloads, their associated network and disk resources, and other information about what your cluster is doing. These abstractions are called *objects*, and are represented by a *kind* in the Kubernetes API.
+Kubernetes contains a number of abstractions that represent the state of your system: deployed containerized applications and workloads, their associated network and disk resources, and other information about what your cluster is doing. These abstractions are called *objects*, and are represented by a *kind- in the Kubernetes API.
 
-* **(Kubernetes) node**
+- **(Kubernetes) node**
 
 A node is a worker machine in Kubernetes.
 
 A worker machine may be a VM or physical machine, depending on the cluster. It has the necessary services to run the workloads and is managed by the master components. The services on a node include Docker, `kubelet` and `kube-proxy`.
 
-* **(Kubernetes) cluster**
+- **(Kubernetes) cluster**
 
 A set of machines, called nodes, that run containerized applications managed by Kubernetes.
 
 A cluster has several worker nodes and at least one master node.
 
-* **(Kubernetes) master**
+- **(Kubernetes) master**
 
-The *master* is responsible for managing the cluster. It coordinates all activities in your cluster, such as scheduling applications, maintaining applications’ desired state, scaling applications, and rolling out new updates.
+The *master- is responsible for managing the cluster. It coordinates all activities in your cluster, such as scheduling applications, maintaining applications’ desired state, scaling applications, and rolling out new updates.
 
 A Kubernetes master automatically handles the scheduling of your services across nodes in the cluster. The master’s automatic scheduling takes the available resources of each node into account.
 
@@ -289,7 +300,7 @@ See the dedicated [README](99-good-practices).
 
 ## Links
 
-* http://kubernetesbyexample.com/
-* https://kubernetes.io/docs/home/
-* https://kubernetes.io/docs/reference/kubectl/cheatsheet/
-* https://hub.docker.com/r/mhausenblas/simpleservice/
+- http://kubernetesbyexample.com/
+- https://kubernetes.io/docs/home/
+- https://kubernetes.io/docs/reference/kubectl/cheatsheet/
+- https://hub.docker.com/r/mhausenblas/simpleservice/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
     - [(Fixed) docker: Ingress not exposed on MacOS](#fixed-docker-ingress-not-exposed-on-macos)
     - [(Optional) If you feel adventurous, only for macOS](#optional-if-you-feel-adventurous-only-for-macos)
     - [Completion](#completion)
+    - [Miscellaneous prerequisites](#miscellaneous-prerequisites)
   - [What this course is and what it's not](#what-this-course-is-and-what-its-not)
     - [What this is](#what-this-is)
     - [What it's *not*](#what-its-not)
@@ -137,6 +138,14 @@ If you are using Zsh, you can add the following to your `.zshrc` file to get aut
 if [ $commands[kubectl] ]; then
   source <(kubectl completion zsh)
 fi
+```
+
+### Miscellaneous prerequisites
+
+If you want to contribute.
+
+```sh
+brew install markdownlint-cli
 ```
 
 ## What this course is and what it's not


### PR DESCRIPTION
# What ?
Refreshing the hands-on

Exercise | Check | Notes
-- | -- | --
05-pods | ✅  |  
06-label-annotation | ✅  | no example of annotation: we can talk about annotations: nginx.ingress.kubernetes.io/ssl-redirect: "false" (from 08-service), and its consequences as an example
07-deployment | ✅  |  README updated with more details
08-service | ⚠️ on M1  | it works fine but no test of the ingress on M1: access to the service via `minishell ip` is not possible, but doable via port fowarding only (meaning with driver: docker, through `minishell service` or `minishell tunnel`). Let's consider update the main README with a M1 warning.
README.md | ✅  |  
CI | ✅ | update of the jobs