### PR TITLE
feat: update pdb apiVersion

### DIFF
--- a/14-pdb/01-pdb.yml
+++ b/14-pdb/01-pdb.yml
@@ -29,7 +29,7 @@ spec:
                         - nginx-pdb
                 topologyKey: kubernetes.io/hostname
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: nginx-pdb

--- a/14-pdb/README.md
+++ b/14-pdb/README.md
@@ -13,7 +13,7 @@ Defining a “Pod Disruption Budget” helps Kubernetes manage your pods when a 
 A `PDB` is configured as this:
 
 ```yml
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: nginx-pdb


### PR DESCRIPTION
## What ?

`policy/v1beta1` is unavailable in v1.25+ ( current kind & minikube versions ) so updating to `policy/v1`